### PR TITLE
fix(jpeg_encode): support numerical matrix and out-of-range values

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -1,6 +1,5 @@
 jpeg_components(::AbstractArray{T}) where T = jpeg_components(T)
 jpeg_components(::Type{CT}) where CT<:Colorant = length(CT)
-jpeg_components(::Type{T}) where T<:Number = 1
 
 jpeg_color_space(::AbstractArray{T}) where T = jpeg_color_space(T)
 jpeg_color_space(::Type{CT}) where CT<:Gray = LibJpeg.JCS_GRAYSCALE

--- a/src/encode.jl
+++ b/src/encode.jl
@@ -40,9 +40,10 @@ julia> buf = jpeg_encode(img); length(buf) # directly write to memory
 
 - [1] [libjpeg API Documentation (libjpeg.txt)](https://raw.githubusercontent.com/libjpeg-turbo/libjpeg-turbo/main/libjpeg.txt)
 """
-function jpeg_encode(img::AbstractMatrix; transpose=false, kwargs...)
+function jpeg_encode(img::AbstractMatrix{T}; transpose=false, kwargs...) where T<:Union{Real, Colorant}
     # quantilized into 8bit sequences first
-    AT = Array{n0f8(eltype(img)), ndims(img)}
+    CT = T <: Colorant ? n0f8(eltype(img)) : Gray{N0f8}
+    AT = Array{CT, ndims(img)}
     # jpegturbo is a C library and assumes row-major memory order, thus `collect` the data into
     # contiguous memeory layout already makes a transpose.
     img = transpose ? convert(AT, img) : convert(AT, PermutedDimsArray(img, (2, 1)))

--- a/src/encode.jl
+++ b/src/encode.jl
@@ -44,6 +44,7 @@ function jpeg_encode(img::AbstractMatrix{T}; transpose=false, kwargs...) where T
     # quantilized into 8bit sequences first
     CT = T <: Colorant ? n0f8(eltype(img)) : Gray{N0f8}
     AT = Array{CT, ndims(img)}
+    clamp01nan!(img)
     # jpegturbo is a C library and assumes row-major memory order, thus `collect` the data into
     # contiguous memeory layout already makes a transpose.
     img = transpose ? convert(AT, img) : convert(AT, PermutedDimsArray(img, (2, 1)))

--- a/test/tst_encode.jl
+++ b/test/tst_encode.jl
@@ -14,6 +14,10 @@ img_rgb = testimage("lighthouse")
         @test data == decode_encode(img, transpose=false)
         @test decode_encode(img, transpose=true) == decode_encode(img', transpose=false)
     end
+
+    # numerical array is treated as Gray image
+    img = Gray.(img_rgb)
+    @test jpeg_encode(Float32.(img)) == jpeg_encode(img)
 end
 
 # keyword checks

--- a/test/tst_encode.jl
+++ b/test/tst_encode.jl
@@ -18,6 +18,11 @@ img_rgb = testimage("lighthouse")
     # numerical array is treated as Gray image
     img = Gray.(img_rgb)
     @test jpeg_encode(Float32.(img)) == jpeg_encode(img)
+
+    # out-of-range values are mapped into [0, 1]
+    img_or = 1.5 .* img
+    img_or[1] = Gray(NaN)
+    @test jpeg_encode(img_or) == jpeg_encode(Float64.(img_or)) == jpeg_encode(clamp01nan!(img_or))
 end
 
 # keyword checks


### PR DESCRIPTION
This follows the common assumption in JuliaImages that numerical
arrays are treated as Gray images.