### PR TITLE
fix: removing C stdio usage

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -32,6 +32,9 @@ jobs:
           - os: macOS-latest
             version: '1'
             arch: x64
+          - os: ubuntu-latest
+            version: '1'
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Without investigating why stdio is broken in x86 system, this commit
replaces the C `fopen` with julia `read` so that it works on x86
system.

The decoding performance is still the same, which indicates that
libjpeg-turbo has no stremline support for FILE.