### PR TITLE
support abbreviated JPEG data streams

### DIFF
--- a/src/encode.jl
+++ b/src/encode.jl
@@ -49,7 +49,8 @@ function jpeg_encode(img::AbstractMatrix{T}; transpose=false, kwargs...) where T
     # contiguous memeory layout already makes a transpose.
     img = transpose ? convert(AT, img) : convert(AT, PermutedDimsArray(img, (2, 1)))
 
-    return _encode(img; kwargs...)
+    table, data = _encode(img; kwargs...)
+    return isempty(table) ? data : (table, data) # for backward compatibility
 end
 
 function jpeg_encode(filename::AbstractString, img; kwargs...)
@@ -57,12 +58,27 @@ function jpeg_encode(filename::AbstractString, img; kwargs...)
         jpeg_encode(io, img; kwargs...)
     end
 end
+function jpeg_encode(table_file::AbstractString, data_file::AbstractString, img; kwargs...)
+    open(table_file, "w") do table_io
+        open(data_file, "w") do data_io
+            jpeg_encode(table_io, data_io, img; kwargs...)
+        end
+    end
+end
 # TODO(johnnychen94): further improve the performance via asynchronously IO and buffer reuse.
 jpeg_encode(io::IO, img; kwargs...) = write(io, jpeg_encode(img; kwargs...))
-
+function jpeg_encode(table_io::IO, data_io::IO, img; kwargs...)
+    table, data = jpeg_encode(img; separate_tables=true, kwargs...)
+    n = write(table_io, table)
+    n += write(data_io, data)
+    return n
+end
 
 function _encode(
     img::Matrix{<:Colorant};
+    separate_tables::Bool = false,
+    skip_tables::Bool = false,
+    skip_data::Bool = false,
     colorspace::Union{Nothing,Type} = nothing,
     # ImageMagick: "the default is to use the estimated quality of your input image if it can be determined, otherwise 92."
     quality::Union{Nothing,Int} = 92,
@@ -109,22 +125,58 @@ function _encode(
         isnothing(Y_density) || (cinfo.Y_density = Y_density)
         isnothing(write_Adobe_marker) || (cinfo.write_Adobe_marker = write_Adobe_marker)
 
-        # set destination
-        # TODO(johnnychen94): allow pre-allocated buffer
-        bufsize = Ref{Culong}(0)
-        buf_ptr = Ref{Ptr{UInt8}}(C_NULL)
-        LibJpeg.jpeg_mem_dest(cinfo_ref, buf_ptr, bufsize)
+        if separate_tables
+            # ref: "Abbreviated datastreams and multiple images" section in libjpeg-turbo API Documentation
+            skip_tables && skip_data && error("`separate_tables` is set, but `skip_tables` or `skip_data` is not set.")
+            if skip_tables
+                table_buf = UInt8[]
+            else
+                bufsize = Ref{Culong}(0)
+                table_buf_ptr = Ref{Ptr{UInt8}}(C_NULL)
+                LibJpeg.jpeg_mem_dest(cinfo_ref, table_buf_ptr, bufsize)
+                LibJpeg.jpeg_write_tables(cinfo_ref)
+                table_buf = unsafe_wrap(Array, table_buf_ptr[], bufsize[]; own=true)
+            end
 
-        # compression stage
-        LibJpeg.jpeg_start_compress(cinfo_ref, true)
-        row_stride = size(img, 1) * jpeg_components(img)
-        row_pointer = Ref{Ptr{UInt8}}(0)
-        while (cinfo.next_scanline < cinfo.image_height)
-            row_pointer[] = pointer(img) + cinfo.next_scanline * row_stride
-            LibJpeg.jpeg_write_scanlines(cinfo_ref, row_pointer, 1);
+            if skip_data
+                data_buf = UInt8[]
+            else
+                bufsize = Ref{Culong}(0)
+                data_buf_ptr = Ref{Ptr{UInt8}}(C_NULL)
+                LibJpeg.jpeg_mem_dest(cinfo_ref, data_buf_ptr, bufsize)
+                LibJpeg.jpeg_start_compress(cinfo_ref, true)
+                row_stride = size(img, 1) * jpeg_components(img)
+                row_pointer = Ref{Ptr{UInt8}}(0)
+                while (cinfo.next_scanline < cinfo.image_height)
+                    row_pointer[] = pointer(img) + cinfo.next_scanline * row_stride
+                    LibJpeg.jpeg_write_scanlines(cinfo_ref, row_pointer, 1);
+                end
+                LibJpeg.jpeg_finish_compress(cinfo_ref)
+                data_buf = unsafe_wrap(Array, data_buf_ptr[], bufsize[]; own=true)
+            end
+
+            return table_buf, data_buf
+        else
+            if skip_tables || skip_data
+                @warn "`skip_tables` and `skip_data` are not used when `separate_tables` is not set."
+            end
+            # set destination
+            # TODO(johnnychen94): allow pre-allocated buffer
+            bufsize = Ref{Culong}(0)
+            buf_ptr = Ref{Ptr{UInt8}}(C_NULL)
+            LibJpeg.jpeg_mem_dest(cinfo_ref, buf_ptr, bufsize)
+
+            # compression stage
+            LibJpeg.jpeg_start_compress(cinfo_ref, true)
+            row_stride = size(img, 1) * jpeg_components(img)
+            row_pointer = Ref{Ptr{UInt8}}(0)
+            while (cinfo.next_scanline < cinfo.image_height)
+                row_pointer[] = pointer(img) + cinfo.next_scanline * row_stride
+                LibJpeg.jpeg_write_scanlines(cinfo_ref, row_pointer, 1);
+            end
+            LibJpeg.jpeg_finish_compress(cinfo_ref)
+            return UInt8[], unsafe_wrap(Array, buf_ptr[], bufsize[]; own=true)
         end
-        LibJpeg.jpeg_finish_compress(cinfo_ref)
-        return unsafe_wrap(Array, buf_ptr[], bufsize[]; own=true)
     finally
         LibJpeg.jpeg_destroy_compress(cinfo_ref)
     end


### PR DESCRIPTION
closes #24

```julia
using Testimages, JpegTurbo

# both tables and data are Vector{UInt8} bytes
tables, data = jpeg_encode(testimage("lighthouse"); separated_tables=true)

img = jpeg_decode(tables, data)
```

@tlnagy I'm not familiar with TIFF format -- I played with it a bit and realize that the data is separated into `ifd[JPEGTABLES]` (the table-only data stream) and data frames. But I don't know how to extract the valid JPEG frame bytes from the file. Can you help put up the JPEG compression support in TIFF images and see what else is needed? Valid JPEG data stream should always start with 0xffd8 and ends with 0xffd9.

Tests and docs are needed.